### PR TITLE
Add default to response so doesnt error if undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const makeRequest = ( replaceErrorsWith, uri ) => {
             }
             return push ( null, R.type ( replaceErrorsWith ) === 'Function' ? replaceErrorsWith ( uri ) : replaceErrorsWith );
         } )
-        .flatMap ( H.wrapCallback ( ( response, callback ) => {
+        .flatMap ( H.wrapCallback ( ( response = {}, callback ) => {
             if ( response.statusCode !== 200 ) {
                 if ( replaceErrorsWith === undefined ) {
                     return callback ( {


### PR DESCRIPTION
When looking through the email issues response was undefined and caused the server to crash so I just added a default in as a quick fix to prevent errors!